### PR TITLE
Change RPC endpoint URL (remove /lb/)

### DIFF
--- a/utils/config.ts
+++ b/utils/config.ts
@@ -28,7 +28,7 @@ export const { chains, publicClient, webSocketPublicClient } = configureChains(
   [
     jsonRpcProvider({
       rpc: (chain) => ({
-        http: `https://eth-${chainString}.rpc.grove.city/v1/lb/${POKT_KEY}`,
+        http: `https://eth-${chainString}.rpc.grove.city/v1/${POKT_KEY}`,
       }),
     }),
   ],
@@ -58,6 +58,6 @@ export default config;
 export const estimationClient = createPublicClient({
   chain,
   transport: http(
-    `https://eth-${chainString}.rpc.grove.city/v1/lb/${POKT_KEY}`,
+    `https://eth-${chainString}.rpc.grove.city/v1/${POKT_KEY}`,
   ),
 });


### PR DESCRIPTION
This is the same change made in the wPOKT bridge frontend and validator repos. Grove updated their URL from `https://[NETWORK].rpc.grove.city/v1/lb/[API_KEY]` to `https://[NETWORK].rpc.grove.city/v1/[API_KEY]` (removing the `/lb`).